### PR TITLE
fix: strict project_id scoping + on-prompt dedup + import parser

### DIFF
--- a/agora_code/cli.py
+++ b/agora_code/cli.py
@@ -1269,11 +1269,18 @@ def _summarize_diff(diff: str, file_path: str) -> str:
         parts.append(f"removed {', '.join(del_fns[:2])}()")
 
     # Import changes
+    def _imp_name(line):
+        # "from foo import Bar" → "Bar"; "import foo.bar" → "foo.bar"
+        if " import " in line:
+            return line.split(" import ", 1)[1].strip().split(",")[0].strip()
+        parts_ = line.split()
+        return parts_[1] if len(parts_) >= 2 else line
+
     if new_imports:
-        import_names = [i.split()[-1] for i in new_imports[:2]]
+        import_names = [_imp_name(i) for i in new_imports[:2]]
         parts.append(f"imported {', '.join(import_names)}")
     if del_imports:
-        import_names = [i.split()[-1] for i in del_imports[:2]]
+        import_names = [_imp_name(i) for i in del_imports[:2]]
         parts.append(f"removed import {', '.join(import_names)}")
 
     # Fallback: show a snippet of the most significant added line
@@ -1305,7 +1312,8 @@ def file_history(file_path, limit):
     """
     from agora_code.vector_store import get_store
 
-    history = get_store().get_file_history(file_path, limit=limit)
+    from agora_code.session import _get_project_id
+    history = get_store().get_file_history(file_path, limit=limit, project_id=_get_project_id())
     if not history:
         _echo(f"📭 No tracked changes for '{file_path}'.")
         _echo("   Changes are tracked automatically via git post-commit hook.")
@@ -1386,7 +1394,7 @@ def learn_from_commit(sha, quiet):
         rows = store.get_file_changes_for_commit(fp, sha, project_id=project_id)
         if not rows:
             # fallback: most recent note for this file regardless of SHA
-            history = store.get_file_history(fp, limit=1)
+            history = store.get_file_history(fp, limit=1, project_id=project_id)
             rows = history if history else []
 
         for row in rows:
@@ -1623,7 +1631,7 @@ def notes(file_path, limit):
     project_id = _get_project_id()
 
     if file_path:
-        rows = store.get_file_history(file_path, limit=limit)
+        rows = store.get_file_history(file_path, limit=limit, project_id=project_id)
     else:
         rows = store.get_recent_file_changes_for_project(project_id, limit=limit)
 
@@ -1970,6 +1978,11 @@ def _install_claude_code_hooks(force: bool) -> None:
 
     # --- on-prompt.sh: auto-set goal + recall relevant learnings on each prompt ---
     on_prompt = f"""#!/bin/sh
+STAMP="/tmp/agora_last_hook_$(basename "$0")"
+NOW=$(date +%s)
+LAST=$(cat "$STAMP" 2>/dev/null || echo 0)
+if [ $((NOW - LAST)) -lt 2 ]; then exit 0; fi
+echo "$NOW" > "$STAMP"
 INPUT=$(cat)
 
 PROMPT=$(printf '%s' "$INPUT" | python3 -c "

--- a/agora_code/vector_store.py
+++ b/agora_code/vector_store.py
@@ -631,16 +631,32 @@ class VectorStore:
         """, (project_id, limit)).fetchall()
         return [dict(r) for r in rows]
 
-    def get_file_history(self, file_path: str, limit: int = 20) -> List[Dict]:
+    def get_file_history(
+        self,
+        file_path: str,
+        limit: int = 20,
+        project_id: Optional[str] = None,
+    ) -> List[Dict]:
         """Return summarized change history for a specific file, newest first."""
-        rows = self._conn_().execute("""
-            SELECT id, file_path, diff_summary, commit_sha, recorded_at_commit_sha,
-                   status, session_id, agent_id AS author, branch, timestamp
-            FROM file_changes
-            WHERE file_path = ?
-            ORDER BY timestamp DESC
-            LIMIT ?
-        """, (file_path, limit)).fetchall()
+        if project_id:
+            rows = self._conn_().execute("""
+                SELECT id, file_path, diff_summary, commit_sha, recorded_at_commit_sha,
+                       status, session_id, agent_id AS author, branch, timestamp
+                FROM file_changes
+                WHERE file_path = ?
+                  AND project_id = ?
+                ORDER BY timestamp DESC
+                LIMIT ?
+            """, (file_path, project_id, limit)).fetchall()
+        else:
+            rows = self._conn_().execute("""
+                SELECT id, file_path, diff_summary, commit_sha, recorded_at_commit_sha,
+                       status, session_id, agent_id AS author, branch, timestamp
+                FROM file_changes
+                WHERE file_path = ?
+                ORDER BY timestamp DESC
+                LIMIT ?
+            """, (file_path, limit)).fetchall()
         return [dict(r) for r in rows]
 
     # ----------------------------------------------------------------------- #
@@ -1064,7 +1080,7 @@ class VectorStore:
         filters = ["cl.commit_sha = ?"]
         params: list = [commit_sha]
         if project_id:
-            filters.append("(l.project_id = ? OR l.project_id IS NULL)")
+            filters.append("l.project_id = ?")
             params.append(project_id)
         where = " AND ".join(filters)
         rows = self._conn_().execute(f"""
@@ -1090,7 +1106,7 @@ class VectorStore:
         params: list = list(commit_shas)
         extra = ""
         if project_id:
-            extra = "AND (l.project_id = ? OR l.project_id IS NULL)"
+            extra = "AND l.project_id = ?"
             params.append(project_id)
         rows = self._conn_().execute(f"""
             SELECT l.id, l.finding, l.evidence, l.confidence, l.tags,
@@ -1127,7 +1143,7 @@ class VectorStore:
             SELECT id, file_path, diff_summary, commit_sha, timestamp
             FROM file_changes
             WHERE file_path LIKE ? AND commit_sha = ?
-              AND (project_id = ? OR project_id IS NULL)
+              AND project_id = ?
             ORDER BY timestamp ASC
         """, (like_pat, commit_sha, project_id)).fetchall()
         return [dict(r) for r in rows]
@@ -1179,7 +1195,7 @@ class VectorStore:
         params: list = [self._pack(query_embedding), k * 2, namespace]
 
         if project_id:
-            filters.append("(l.project_id = ? OR l.project_id IS NULL)")
+            filters.append("l.project_id = ?")
             params.append(project_id)
         if branch:
             filters.append("(l.branch = ? OR l.branch IS NULL)")
@@ -1227,7 +1243,7 @@ class VectorStore:
         filters = ["(namespace = ? OR namespace IS NULL)"]
         base_params: list = [namespace]
         if project_id:
-            filters.append("(project_id = ? OR project_id IS NULL)")
+            filters.append("project_id = ?")
             base_params.append(project_id)
         if branch:
             filters.append("(branch = ? OR branch IS NULL)")


### PR DESCRIPTION
- vector_store: remove OR project_id IS NULL from all 5 learnings queries (get_learnings_for_commit, get_learnings_for_commits, get_file_changes_for_commit, search_learnings_semantic, search_learnings_keyword) — old NULL-project rows were bleeding into every project's recall and inject
- vector_store: get_file_history now accepts project_id param and filters when provided — was showing cross-project results for same filename
- cli: pass project_id to all get_file_history callers (file-history cmd, notes cmd, learn-from-commit fallback)
- cli: add 2-second dedup stamp to on-prompt.sh template — new installs were missing the guard present in the already-installed hook
- cli: fix _summarize_diff import parser to handle 'from X import Y' → Y instead of splitting on whitespace and taking last token